### PR TITLE
docs: update README.md with additional message parameters example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ const warnOnce = require('warn-once');
 // ...
 
 warnOnce(someCondition, 'This is a warning message');
+
+// additional message strings as parameters
+// You can add 'n' number of arguments.
+warnOnce(someCondition, 'message 1', 'message 2', 'message 3')
 ```
 
 You can call `warnOnce` multiple times, but if the warning was printed already, it'll not be printed again.


### PR DESCRIPTION
Hey @satya164, thanks for this library. 

This PR contains README.md updated with an example demonstrating the ability to pass message strings as arguments.

```
// additional message strings as parameters
// You can add 'n' number of arguments.
warnOnce(someCondition, 'message 1', 'message 2', 'message 3')
```

I confirmed this by looking at the source code - index.js with the below function declaration:

```
function warnOnce(condition, ...rest) {
```

`...rest` tells us that we can pass in n number of arguments.